### PR TITLE
refactor: simplify config/logging; docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 LangGraph-based, function-defined agents to analyze a portfolio and emit a minimal report.
 
+See the architecture overview in `docs/Architecture.md` for a deeper dive.
+
 ## Quickstart
 
 1. Ensure Python 3.13.7 is available (e.g., via pyenv) and clone the repo.
@@ -101,7 +103,7 @@ The `portfolio-advisor` CLI accepts the following parameters. All options can al
 
 - `--skip-llm-cache`
   - Force LLM calls to bypass cache lookup but write results to the cache.
-  - Env: `SKIP_LLM_CAHCE=1` has the same effect.
+  - Env: `SKIP_LLM_CACHE=1` has the same effect.
   - Cache DB persists at `./cache/langchain_cache.sqlite3`.
 
 - `--log-level`

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,103 @@
+# Architecture Overview
+
+This document explains the overall design of PortfolioAdvisor, the data flow through its agents,
+configuration surface, and guidance for extending the system.
+
+## Goals
+- Simple, reliable end-to-end portfolio ingestion and analysis
+- Minimal, opinionated configuration with sensible defaults
+- Clear boundaries between ingestion, parsing, resolution, and analysis
+
+## High-level Flow
+
+1. CLI gathers paths and overrides and calls the application entrypoint.
+2. The entrypoint builds settings, configures logging, and initializes the LangChain cache.
+3. A LangGraph state machine orchestrates agents:
+   - ingestion → planner → parse (fan-out) → resolve (fan-out) → analyst
+4. Results are compiled into `analysis.md` and a debugging JSON file with resolved/unresolved items.
+
+Sequence sketch:
+
+```
+cli → analyze_portfolio → build_graph →
+  ingestion ──> planner ──> dispatch_parse ──(fan-out: doc)→ parse_one ──> join_after_parse ──>
+  dispatch_resolve ──(fan-out: holding)→ resolve_one ──> join_after_resolve ──> analyst → END
+```
+
+## Graph State Contract
+
+The LangGraph state is a dictionary with well-known keys:
+- `settings`: application settings instance
+- `raw_docs`: list[dict] from ingestion (path, name, mime_type, as_text, metadata)
+- `plan`: planner output (`steps`, `rationale`)
+- `parsed_holdings`: additive channel of dicts produced by parse fan-out
+- `resolved_holdings`: additive channel of canonical holding dicts
+- `unresolved_entities`: additive channel of unresolved records with `reason`
+- `errors`: additive channel of error strings
+- `analysis`: final narrative string (optional)
+
+## Agents
+
+- Ingestion (`agents/ingestion.py`)
+  - Discovers files in `input_dir`, extracts plain text for common types (txt/md/html/csv/eml)
+  - Applies a 2 MiB hard cap per file to protect memory
+  - Ignores OS artifacts like `.DS_Store`
+
+- Parser (`agents/parser.py`)
+  - Prompts an LLM to emit strict JSON conforming to `ParsedHoldingsResult`
+  - Retries on schema validation issues (`PARSER_MAX_RETRIES`, default 2)
+  - Truncates input to `PARSER_MAX_DOC_CHARS` (default 20000)
+
+- Resolver (`agents/resolver.py` + `tools/symbol_resolver.py`)
+  - Optionally queries Polygon via `services/polygon_client.py`
+  - Heuristic ranking: active + preferred MIC + currency match
+  - Offline mode when no API key; returns unresolved records
+
+- Analyst (`agents/analyst.py`)
+  - Produces a simple narrative summary using the LLM
+
+## Models
+
+- `models/parsed.py`
+  - `ParsedHolding`, `ParsedHoldingsResult` (schema-driven LLM output)
+
+- `models/canonical.py`
+  - `InstrumentKey` (string form `cid:asset_class:locale:mic:symbol`)
+  - `CanonicalHolding` (normalized, enriched record)
+
+## Configuration
+
+Settings are defined in `src/portfolio_advisor/config.py` and loaded from environment (with `.env`
+in dev) and may be overridden via CLI flags.
+
+- Required: `--input-dir`, `--output-dir`
+- LLM: `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_MODEL`, `REQUEST_TIMEOUT_S`, `MAX_TOKENS`, `TEMPERATURE`
+- Logging: `LOG_LEVEL`, `LOG_FORMAT`, `VERBOSE`, `AGENT_PROGRESS`
+- Parser: `PARSER_MAX_RETRIES`, `PARSER_MAX_DOC_CHARS`
+- Polygon / Resolver: `POLYGON_API_KEY`, `POLYGON_BASE_URL`, `POLYGON_TIMEOUT_S`,
+  `RESOLVER_DEFAULT_LOCALE`, `RESOLVER_PREFERRED_MICS`, `RESOLVER_CONFIDENCE_THRESHOLD`
+- Cache: `SKIP_LLM_CACHE` (when set, bypasses read but writes results to cache)
+
+Notes:
+- Logging is configured from `Settings` and may be influenced by env variables for convenience.
+- With no `OPENAI_API_KEY`, a stub LLM path returns placeholder text for tests/demos.
+
+## Logging and Errors
+
+- Logs default to plain/INFO; JSON format is supported.
+- Library noise is reduced by default; enabling `AGENT_PROGRESS` raises verbosity for
+  LangGraph/LangChain to INFO.
+- Errors raise meaningful exceptions; file and configuration errors include context.
+
+## Extensibility
+
+- Adding a new provider: implement a thin client in `services/` and adapt `SymbolResolver` heuristics
+- Adding a new agent: create a node function, add to the graph, and update state keys
+- Adjusting prompts or retry logic: update `agents/parser.py` prompt constants and tuning
+
+## Repository layout
+
+- `src/portfolio_advisor/`: application modules
+- `tests/`: unit and integration tests
+- `docs/`: documentation (this file)
+- `scripts/`: developer tooling (bootstrap, lint, format, test)

--- a/env.example
+++ b/env.example
@@ -16,7 +16,7 @@ AGENT_PROGRESS=
 
 # Caching
 # When set to 1, bypasses cache lookup but writes fresh results to cache
-SKIP_LLM_CAHCE=
+SKIP_LLM_CACHE=
 
 # Parser (LLM Parsing Agent)
 PARSER_MAX_RETRIES=2

--- a/src/portfolio_advisor/agents/analyst.py
+++ b/src/portfolio_advisor/agents/analyst.py
@@ -1,3 +1,5 @@
+"""Analyst agent: composes a concise narrative summary from graph results."""
+
 from __future__ import annotations
 
 import logging

--- a/src/portfolio_advisor/agents/ingestion.py
+++ b/src/portfolio_advisor/agents/ingestion.py
@@ -1,3 +1,5 @@
+"""Ingestion agent: discovers files and extracts normalized plain text units."""
+
 from __future__ import annotations
 
 import csv

--- a/src/portfolio_advisor/agents/parser.py
+++ b/src/portfolio_advisor/agents/parser.py
@@ -1,3 +1,5 @@
+"""Parser agent: prompts an LLM to extract candidate holdings as strict JSON."""
+
 from __future__ import annotations
 
 import json

--- a/src/portfolio_advisor/agents/resolver.py
+++ b/src/portfolio_advisor/agents/resolver.py
@@ -1,3 +1,5 @@
+"""Resolver agent: normalizes parsed holdings using provider data when available."""
+
 from __future__ import annotations
 
 import logging

--- a/src/portfolio_advisor/cli.py
+++ b/src/portfolio_advisor/cli.py
@@ -20,8 +20,6 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--temperature", type=float)
 
     # Parser settings (override env)
-    p.add_argument("--parser-max-concurrency", type=int)
-    p.add_argument("--parser-max-rpm", type=int)
     p.add_argument("--parser-max-retries", type=int)
     p.add_argument("--parser-max-doc-chars", type=int)
 

--- a/src/portfolio_advisor/config.py
+++ b/src/portfolio_advisor/config.py
@@ -63,7 +63,7 @@ class Settings(BaseSettings):
     verbose: bool = Field(default=False, alias="VERBOSE")
     agent_progress: bool = Field(default=False, alias="AGENT_PROGRESS")
     # Caching
-    skip_llm_cache: bool = Field(default=False, alias="SKIP_LLM_CAHCE")
+    skip_llm_cache: bool = Field(default=False, alias="SKIP_LLM_CACHE")
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/src/portfolio_advisor/llm.py
+++ b/src/portfolio_advisor/llm.py
@@ -1,3 +1,5 @@
+"""LLM utilities: build and share chat model instances with logging wrappers."""
+
 from __future__ import annotations
 
 import logging

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -13,7 +13,7 @@ def test_cache_db_created_default(tmp_path, monkeypatch):
 
     # Ensure stub LLM path
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("SKIP_LLM_CAHCE", raising=False)
+    monkeypatch.delenv("SKIP_LLM_CACHE", raising=False)
 
     analyze_portfolio(str(in_dir), str(out_dir))
 
@@ -29,7 +29,7 @@ def test_skip_cache_bypasses_lookup_but_writes(tmp_path, monkeypatch):
 
     # Ensure stub LLM path and enable skip mode
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setenv("SKIP_LLM_CAHCE", "1")
+    monkeypatch.setenv("SKIP_LLM_CACHE", "1")
 
     analyze_portfolio(str(in_dir), str(out_dir))
 


### PR DESCRIPTION
Simplify configuration, centralize logging via Settings, remove unused parser CLI flags, add module docstrings, and add docs/Architecture.md. README updated to link Architecture and fix SKIP_LLM_CACHE env name.