### PR TITLE
Stock charts: 1Y candlesticks in report/ (mplfinance)

### DIFF
--- a/docs/research-wavelet-analysis.md
+++ b/docs/research-wavelet-analysis.md
@@ -1,0 +1,366 @@
+
+
+# **A Comprehensive Guide to Financial Time Series Analysis Using the Maximal Overlap Discrete Wavelet Transform**
+
+## **Section 1: The Maximal Overlap Discrete Wavelet Transform (MODWT): A Superior Lens for Financial Markets**
+
+Financial time series, such as stock prices and trading volumes, are notoriously difficult to analyze due to their complex, non-stationary nature. They are characterized by time-varying volatility, unpredictable structural breaks, and the simultaneous influence of market participants operating on vastly different time horizons—from high-frequency traders to long-term institutional investors.1 Traditional analytical tools often fall short in this environment. The Maximal Overlap Discrete Wavelet Transform (MODWT) emerges as a uniquely powerful and theoretically sound methodology for dissecting these complexities, offering a multi-resolution view that aligns with the intrinsic structure of market dynamics. This section establishes the foundational principles of MODWT, detailing the properties that make it the superior choice for the analytical tasks of quantifying momentum, risk, and trend reversals in financial markets.
+
+### **1.1 A Superior Lens for Non-Stationary Markets: Beyond Fourier and DWT**
+
+The primary challenge in financial data analysis is non-stationarity. Tools like the Fourier transform, which decompose a signal into a sum of sine and cosine waves, are fundamentally ill-suited for this task. The Fourier transform assumes the signal's frequency content is constant over time (stationarity) and provides a global frequency representation, losing all time-domain information. It can reveal *what* frequencies are present in a time series, but not *when* they occurred, making it impossible to analyze localized events like market crashes or volatility spikes.3
+
+The standard Discrete Wavelet Transform (DWT) was developed to overcome this limitation by providing time-frequency localization. However, the DWT introduces a critical flaw for time series analysis through its decimation (or downsampling) process at each level of decomposition. This decimation makes the DWT *shift-variant*. A small shift in the starting point of the input time series can lead to a dramatically different set of wavelet coefficients. For financial analysis, where the timing of peaks, troughs, and volatility clusters is paramount, this property is unacceptable as it makes the analysis dependent on an arbitrary starting point.
+
+The MODWT resolves this fundamental issue. As an undecimated, or stationary, wavelet transform, it is **shift-invariant**.9 This property ensures that a circular shift in the input time series results in an identical circular shift in the wavelet and scaling coefficients at every level. Features within the data, such as a price peak or a volume spike, maintain their temporal alignment in the decomposed series, regardless of where they appear in the original data stream. This temporal fidelity is a non-negotiable requirement for building reliable financial indicators and forecasting models.
+
+Furthermore, the MODWT offers significant practical advantages. Unlike the DWT, which often requires the length of the time series to be a power of two (2J), the MODWT is well-defined for any sample size N.12 This removes a major operational hurdle, as real-world financial datasets rarely conform to such restrictive length requirements.
+
+### **1.2 Decomposing Variance: From a Single Number to a Multi-Scale Spectrum**
+
+A single volatility metric, such as the annualized standard deviation of returns, is a blunt instrument. It aggregates the contributions of diverse market forces—short-term speculative noise, medium-term sector rotations, and long-term economic cycles—into one number, masking the underlying risk structure.15
+
+A cornerstone property of the MODWT is its ability to perform an exact, additive **partitioning of variance** across different time scales.9 For a given time series, the sum of the variances of the wavelet coefficients at each decomposition level, plus the variance of the final scaling coefficients, is precisely equal to the total variance of the original series. This is an energy-preserving property that allows for a rigorous analysis of variance (ANOVA) framework.
+
+Each level of the MODWT decomposition corresponds to a specific dyadic (powers of two) frequency band. For daily data, level 1 captures oscillations between 2 and 4 days, level 2 between 4 and 8 days, level 3 between 8 and 16 days, and so on. By calculating the variance of the wavelet coefficients at each level, one can construct a "volatility spectrum" that quantifies the contribution of each time scale to the total risk of the asset.15 This decomposition enables a far more nuanced understanding of risk. For instance, it can reveal whether an asset's volatility is primarily driven by short-term, high-frequency noise (suggesting high trading costs and slippage for short-term strategies) or by its sensitivity to longer-term business cycles (suggesting macroeconomic risk). This scale-based variance analysis is the foundation for the volatility and risk metrics developed later in this report.
+
+### **1.3 Selecting the Optimal Mother Wavelet (Q1): A Strategic Decision**
+
+The mother wavelet is the fundamental building block of the transform, a small, wave-like function that is scaled and shifted to match features in the data. The choice of mother wavelet is not a trivial technical detail but a critical modeling decision that directly influences the quality and interpretation of the results.2 The objective is to select a wavelet whose mathematical properties best align with the characteristics of the financial features being analyzed. For the MODWT, the choice must be an orthogonal wavelet.9 Key properties to consider include support length, vanishing moments, and symmetry.
+
+* **Support Length:** This refers to the finite length of the wavelet filter. Wavelets with shorter support (e.g., Haar, db2, sym2) are more effective at detecting and localizing sharp, abrupt events like price spikes or flash crashes. However, they are less smooth and can produce blocky approximations. Wavelets with longer support provide smoother representations of the data, which is better for analyzing underlying trends, but they may blur the precise timing of transient events.9  
+* **Vanishing Moments (N):** A wavelet with N vanishing moments is orthogonal to polynomials of degree up to N−1. This means that if a signal contains a smooth trend that can be approximated by a low-degree polynomial, a wavelet with a sufficient number of vanishing moments will produce near-zero detail coefficients in that region. This property is exceptionally useful for trend analysis, as it effectively isolates the trend component into the scaling coefficients, leaving the detail coefficients to represent the deviations from that trend.9 This property is also central to the wavelet-based derivative approximation method discussed in Section 4\.17  
+* **Symmetry:** Symmetric wavelets are associated with linear phase filters. In signal processing terms, this means they do not introduce phase distortion or time delays into the decomposed components. This is of paramount importance for financial analysis, as it ensures that features detected in the wavelet domain are precisely aligned in time with their occurrence in the original series. The Daubechies (dbN) family offers minimal asymmetry for a given support length, making them a popular choice. The Symlets (symN) are designed to be "least asymmetric" or nearly symmetric, offering an excellent compromise. The Coiflets (coifN) are also nearly symmetric.9
+
+The selection of a near-symmetric wavelet is not merely a preference but a choice that is theoretically synergistic with the core advantage of the MODWT. The entire purpose of using the shift-invariant MODWT is to preserve the exact temporal location of financial events. Using a highly asymmetric wavelet would introduce phase shifts, partially negating this benefit by misaligning the detected features in time. Therefore, to fully exploit the power of MODWT's shift-invariance, a wavelet with minimal phase distortion is required. This makes the Symlet (symN) family a particularly strong candidate for the analyses proposed in this report.
+
+For the user's specific tasks, a **Symlet (symN)** or **Daubechies (dbN)** wavelet with a moderate number of vanishing moments (e.g., N=4 to 8, such as sym4 or db8) represents a robust and versatile starting point. The symN family is particularly well-suited for approximating derivatives (velocity and acceleration), while the dbN family provides a well-rounded balance for general-purpose feature detection and volatility analysis.
+
+**Table 1: Mother Wavelet Selection Guide for Financial Analysis**
+
+| Wavelet Family | Support Width | Vanishing Moments (N) | Symmetry | Recommended Use Case |
+| :---- | :---- | :---- | :---- | :---- |
+| Haar (haar) | 1 | 1 | Symmetric | Detecting sharp, perfectly localized step-changes or discontinuities. Can be too simplistic for smooth data. |
+| Daubechies (dbN) | 2N−1 | N | Asymmetric | Good general-purpose analysis, feature detection, and volatility decomposition. db4 or db8 are common choices. |
+| Symlets (symN) | 2N−1 | N | Near Symmetric | Excellent for approximating derivatives (velocity/acceleration) due to low phase distortion. Ideal for trend reversal analysis. |
+| Coiflets (coifN) | 3N−1 | N | Near Symmetric | Similar to Symlets, with additional moment conditions on the scaling function, providing good approximations for smooth trends. |
+
+### **1.4 Managing the Edges: Boundary Conditions in Financial Data (Q2)**
+
+Because wavelet filters have a finite length, applying them near the start or end of a finite time series requires a decision on how to handle the "edges" where the filter extends beyond the available data. This is the boundary handling problem, and an improper choice can introduce significant artifacts that contaminate the wavelet coefficients, particularly those at the end of the series which are most critical for forecasting.18
+
+Two common methods are periodic and reflection padding:
+
+* **Periodic Padding:** This method treats the time series as if it were circular, wrapping the end of the series back to the beginning. For a typical financial time series that exhibits a strong trend, this creates a large, artificial jump or discontinuity at the boundary where the high end-value meets the low start-value. This artificial jump introduces substantial energy into the wavelet coefficients near the boundaries, distorting the analysis.19 While it is the default in some software packages, it is generally unsuitable for trending financial data.  
+* **Reflection (Symmetric) Padding:** This method extends the signal by reflecting it at the boundaries, as if placing a mirror at the start and end points. This creates a much smoother and more plausible extension for trending data, avoiding the introduction of artificial discontinuities.10
+
+For all financial analysis, and especially for any task involving forecasting or the analysis of the most recent data points, **reflection padding is the strongly recommended method**. It minimizes boundary artifacts and preserves the integrity of the wavelet coefficients that are essential for making forward-looking inferences. The combination of the **MODWT transform, a near-symmetric mother wavelet, and reflection boundary handling** constitutes a "best practices" triad for rigorous financial time series analysis.
+
+## **Section 2: A Practical Implementation Framework in Python (Q3)**
+
+Selecting the right software library and implementing the MODWT correctly are as crucial as the underlying theory. The Python ecosystem offers robust tools for wavelet analysis, but a nuanced understanding is required to ensure the theoretical properties of MODWT are correctly realized in practice. This section provides a definitive recommendation on the optimal Python library and a detailed guide to its proper implementation for financial analysis.
+
+### **2.1 The Python Wavelet Ecosystem: PyWavelets vs. modwtpy**
+
+Two primary libraries emerge for performing MODWT in Python: PyWavelets, the foundational package for wavelet analysis, and modwtpy, a more specialized library.
+
+* **PyWavelets:** This is the de facto standard for wavelet transforms in Python. It is a mature, well-documented, and actively maintained open-source project with a large user base.21 Its core computational routines are written in C and Cython, ensuring high performance.  
+  PyWavelets does not have a function explicitly named modwt. Instead, it provides the Stationary Wavelet Transform (swt), which is often used as a synonym for MODWT.11 However, there is a critical implementation detail: the  
+  PyWavelets.swt documentation clarifies that it is "closely related" to the MODWT described in seminal texts (e.g., Percival & Walden, 2000\) but uses a slightly different underlying implementation known as the "algorithme à trous".11 To achieve the key properties of MODWT, specifically energy conservation and variance partitioning, the transform must be performed with an orthogonal wavelet, and the  
+  swt function must be called with the parameters norm=True and trim\_approx=True.11  
+* **modwtpy:** This is a smaller, community-developed library created with the specific goal of replicating the functionality and interface of MATLAB's popular modwt and modwtmra functions.25 It acts as a convenient wrapper, using the wavelet filters from  
+  PyWavelets as its foundation.25 Its main advantage is familiarity and ease of transition for users coming from a MATLAB environment, as it aims for direct parity with that implementation. However, as a smaller project, it has less extensive community support and may not be as actively maintained as the core  
+  PyWavelets library.
+
+**Table 2: Python MODWT Library Comparison**
+
+| Feature | PyWavelets.swt | modwtpy |
+| :---- | :---- | :---- |
+| **Core Transform** | Stationary Wavelet Transform ("algorithme à trous") | MODWT (Percival & Walden implementation) |
+| **Function Name Parity with MATLAB** | No (swt) | Yes (modwt, modwtmra) |
+| **Boundary Handling** | Manual pre-padding required before transform | Built-in (reflection or periodic) |
+| **Normalization for Variance Partitioning** | Requires norm=True parameter | Handled internally as part of the algorithm |
+| **Dependencies** | numpy | PyWavelets, pandas |
+| **Community Support & Maintenance** | High (foundational library) | Lower (specialized wrapper) |
+
+### **2.2 Recommended Implementation Strategy**
+
+For developing a new, robust, and sustainable financial analysis feature, the recommended strategy is to use the **PyWavelets** library. Its status as the foundational package ensures better long-term support, a wider range of features, and a larger community for troubleshooting. While it requires more careful implementation to correctly emulate MODWT properties, this explicit control leads to a more transparent and verifiable analysis pipeline.
+
+The implementation must address two key points that are potential pitfalls for the unwary user: normalization and boundary handling.
+
+1\. Normalization for Variance Partitioning:  
+As noted, to ensure the transform correctly partitions the variance of the original series—a property central to the volatility analysis in Section 5—the pywt.swt function must be called with the norm=True argument. This normalizes the coefficients such that their energy equals the energy of the input signal, which is a key characteristic of the MODWT.11  
+2\. Boundary Handling via Pre-Padding:  
+The pywt.swt function does not have a built-in mode parameter for handling boundary conditions. The documentation states that the input signal length must be a multiple of 2level, where level is the depth of the decomposition, and that padding to an appropriate length should be performed by the user beforehand.11 This is a critical manual step. The  
+pywt.pad function can be used for this purpose, and the recommended mode for financial time series is 'symmetric' or 'reflect', which correspond to the reflection padding discussed in Section 1.4.19 An incorrect or omitted padding step will lead to errors or inaccurate results.
+
+A robust implementation pattern in Python would therefore involve the following steps:
+
+1. Determine the desired decomposition level, J.  
+2. Calculate the required padded length, which must be the next highest multiple of 2J.  
+3. Use pywt.pad to extend the financial time series to this new length using the 'symmetric' mode.  
+4. Perform the Stationary Wavelet Transform on the padded series using pywt.swt, specifying the chosen mother wavelet and setting norm=True.  
+5. After the transform, truncate the resulting coefficient series back to the original length of the time series to remove the artifacts from padding.
+
+This explicit, multi-step process ensures that the transform is applied correctly and that the theoretical properties of the MODWT are preserved, preventing subtle but significant errors in the downstream financial analysis.
+
+## **Section 3: Multi-Scale Analysis of Price and Volume Dynamics (Q4)**
+
+A common mistake in quantitative analysis is to apply a single processing technique uniformly to different types of data. Financial price and volume series, while related, are driven by distinct underlying processes and possess different statistical properties. A successful wavelet analysis must acknowledge these differences and tailor the preprocessing pipeline accordingly. The term "trend" itself requires a context-specific definition for each series to yield meaningful results.
+
+### **3.1 Preprocessing Price Series: Taming Non-Stationarity**
+
+Raw asset prices are typically non-stationary and exhibit behavior akin to a random walk with drift, formally known as an integrated process of order one, or I(1). Applying a wavelet transform directly to such a series is problematic, as the powerful, low-frequency trend component will dominate the decomposition at all scales, masking the more subtle, higher-frequency dynamics that are often of interest for trading and risk management.
+
+The standard and theoretically sound approach to handle this is to transform the price series into a more stationary representation. For financial data, **logarithmic returns** are the industry standard. The log return at time t, calculated as rt​=log(Pt​/Pt−1​), has several desirable properties:
+
+* It approximates the percentage change in price for small changes.  
+* Log returns are time-additive, whereas simple returns are not.  
+* The resulting series is typically much closer to being stationary, with a mean close to zero and a more stable variance, making it suitable for wavelet decomposition.27
+
+Therefore, for all analyses related to volatility, risk, velocity, and acceleration, the MODWT will be applied to the **log-return series**.
+
+However, for the specific task of identifying trend reversals, the objective is to analyze the trend itself, not to remove it. In this case, applying the MODWT to the **log-price series** is the correct approach. The low-frequency smooth component (scaling coefficients) of this decomposition will directly represent the underlying trend, which can then be analyzed for signs of deceleration and reversal.28
+
+### **3.2 Interpreting and Preprocessing Volume Series**
+
+Trading volume is a fundamentally different type of time series. Its statistical properties include:
+
+* **Positivity:** Volume can only be zero or positive.  
+* **Heteroskedasticity:** Volume series are often highly volatile, with periods of high activity followed by periods of low activity.  
+* **Seasonality and Trends:** Volume often exhibits strong intra-day, weekly, or annual seasonal patterns. It can also possess a long-term secular trend, reflecting changes in market structure, liquidity, or overall participation over many years.29
+
+When the user query asks to analyze the "volume trend," it is crucial to distinguish between the long-term secular trend (e.g., a multi-decade increase in market activity) and the more tactically relevant cyclical variations in trading activity. For most trading applications, the latter is the "trend" of interest. A naive application of MODWT to raw volume data would conflate these effects.
+
+A tailored preprocessing pipeline for volume is therefore required:
+
+1. **Log Transform:** To stabilize the variance and handle the positive nature of the data, a logarithmic transform is applied first: Vt′​=log(Vt​+1). The "+1" is added to avoid issues with zero-volume days.  
+2. **Detrending and Deseasonalizing:** To isolate the cyclical component, the long-term secular trend and any strong, predictable seasonalities must be removed. This can be achieved by fitting a simple linear or polynomial regression against time and subtracting the fitted trend. A more sophisticated method is to perform a preliminary wavelet decomposition and use the resulting smooth (scaling coefficient) component as the trend to be removed.
+
+After this preprocessing, the MODWT is applied to the detrended, log-transformed volume series. The resulting detail coefficients at various scales will represent the cyclical "volume trend" at different time horizons, free from the distortions of the long-term secular trend and heteroskedasticity.
+
+### **3.3 A Unified Preprocessing and Analysis Pipeline**
+
+The distinct statistical properties of price and volume, combined with the specific analytical goals, necessitate a differentiated approach. The following pipeline summarizes the correct preprocessing and component selection for each task outlined in the user query:
+
+* **For Price Velocity, Acceleration, and Volatility Analysis:**  
+  1. Start with the closing price series, Pt​.  
+  2. Calculate the log-return series: rt​=log(Pt​)−log(Pt−1​).  
+  3. Apply MODWT to the log-return series, rt​.  
+  4. Analyze the **detail coefficients (Dj​)** for velocity and their variance for scale-based volatility.  
+* **For Price Trend and Reversal Analysis:**  
+  1. Start with the closing price series, Pt​.  
+  2. Calculate the log-price series: log(Pt​).  
+  3. Apply MODWT to the log-price series, log(Pt​).  
+  4. Analyze the **smooth/scaling coefficients (SJ​)** to identify the underlying trend and its acceleration.  
+* **For Volume Trend Analysis:**  
+  1. Start with the trading volume series, Vt​.  
+  2. Apply a log transform: Vt′​=log(Vt​+1).  
+  3. Detrend the Vt′​ series to create a stationary, cyclical series, Vt′′​.  
+  4. Apply MODWT to the detrended series, Vt′′​.  
+  5. Analyze the **detail coefficients (Dj​)** to identify cyclical trends in volume activity.
+
+This structured approach ensures that the wavelet transform is applied to data with appropriate statistical properties, and that the correct resulting components are used for each specific financial interpretation, thereby maximizing the validity and utility of the analysis.
+
+## **Section 4: Quantifying Market Momentum: Velocity and Acceleration**
+
+Traditional methods for calculating price velocity (rate of change) and acceleration (rate of change of velocity) often rely on simple finite differences of the price series.32 While intuitive, this approach is highly susceptible to noise, leading to erratic and unreliable indicators. A wavelet-based framework offers a far more robust and elegant solution by leveraging the intrinsic properties of the transform itself. This approach reframes the wavelet transform from a simple decomposition tool into a sophisticated feature engineering engine, where the resulting coefficients have direct physical interpretations as multi-scale measures of market momentum.
+
+### **4.1 From Wavelet Coefficients to Derivatives: A Unified Approach**
+
+A powerful mathematical property of wavelet transforms is their connection to differentiation. A wavelet transform using a mother wavelet with N vanishing moments can be shown to act as a smoothed, N-th order differentiator.17 This provides a method to calculate derivatives that is inherently denoised and scale-dependent. Instead of a noisy, two-step process of "denoise, then differentiate," the wavelet transform accomplishes both in a single, theoretically sound operation.
+
+The MODWT detail coefficients, Dj​(t), which capture the differences between successive smooths of the signal, can be interpreted as a scaled and smoothed representation of the signal's first derivative—its velocity—at the time scale corresponding to level j.
+
+The methodology for calculating multi-scale velocity and acceleration is as follows:
+
+1. **Multi-Scale Velocity:**  
+   * Decompose the log-return series, rt​, using MODWT with a suitable near-symmetric wavelet (e.g., sym4 or sym8). A higher number of vanishing moments provides a smoother derivative estimate.  
+   * The resulting time series of detail coefficients at each level j, Dj​, directly represents the **price velocity** over the corresponding time scale (e.g., D1​ is the 2-4 day velocity, D4​ is the 16-32 day velocity). These coefficients quantify the rate of change of the price at that specific frequency band.  
+2. **Multi-Scale Acceleration:**  
+   * Price acceleration is the second derivative of price, or the first derivative of velocity. This can be calculated in two robust ways:  
+     * **Method A (Iterative Decomposition):** Apply the MODWT again, this time to each of the velocity series (Dj​) obtained in the previous step. The detail coefficients of this second transform will represent the acceleration at various sub-scales within each original velocity scale.  
+     * **Method B (Direct Calculation from Price):** A more direct approach is to recognize that the wavelet transform itself can approximate higher-order derivatives. Using a wavelet with a sufficient number of vanishing moments on the log-price series can yield coefficients that relate to the second derivative.17 However, for clarity and direct interpretation, applying the transform to the velocity (log-return) series is more straightforward. The detail coefficients of the log-return series represent the  
+       *change* in log price, which is velocity. Therefore, the first difference of these detail coefficients, ΔDj​(t)=Dj​(t)−Dj​(t−1), provides a robust, scale-specific measure of acceleration.
+
+### **4.2 Interpreting Multi-Scale Momentum**
+
+This methodology yields not a single value for velocity and acceleration, but a rich spectrum of momentum indicators across different investment horizons. The interpretation of these indicators provides deep insights into market structure:
+
+* **High Velocity/Acceleration at Short Scales (e.g., D1​,D2​):** This indicates strong, short-term momentum or sharp changes in that momentum. Such signals are often associated with reactions to news events, algorithmic trading activity, or speculative fervor. They tend to be mean-reverting and less persistent.  
+* **High Velocity/Acceleration at Long Scales (e.g., D5​,D6​, and the smooth component SJ​):** This indicates a powerful, persistent underlying trend or a significant shift in that trend's trajectory. These movements are more likely driven by fundamental factors, macroeconomic shifts, or sustained changes in long-term investor sentiment.
+
+This multi-scale view is invaluable for strategic decision-making. It allows an analyst to distinguish between a fleeting, noise-driven price movement and a genuine, fundamentally-backed change in the market's primary trend. For example, a sharp upward acceleration at short scales with no corresponding acceleration at longer scales may signal a speculative blow-off top, whereas acceleration across multiple scales simultaneously provides strong confirmation of a new, durable trend.
+
+**Table 3: Wavelet Component Interpretation Matrix**
+
+| Analytical Task | Primary Wavelet Component(s) | Interpretation |
+| :---- | :---- | :---- |
+| **Underlying Trend** | Scaling Coefficients (SJ​) of log-price | The smooth, long-term trajectory of the asset price. |
+| **Short-Term Volatility (2-8 days)** | Variance of Detail Coefficients D1​,D2​ of log-returns | Risk contribution from high-frequency noise and short-term trading. |
+| **Medium-Term Volatility (8-32 days)** | Variance of Detail Coefficients D3​,D4​ of log-returns | Risk contribution from weekly/monthly cyclical behavior. |
+| **Short-Term Velocity** | Detail Coefficients D1​,D2​ of log-returns | Rate of price change due to short-term dynamics. |
+| **Trend Velocity** | First derivative of Scaling Coefficients SJ​ of log-price | The speed and direction of the primary, underlying trend. |
+| **Trend Acceleration** | Second derivative of Scaling Coefficients SJ​ of log-price | The rate of change of the primary trend's velocity. |
+| **Trend Reversal Signal** | Zero-crossing of Trend Acceleration | A potential inflection point in the primary trend. |
+
+This interpretation matrix serves as a crucial "decoder ring," mapping the mathematical outputs of the MODWT to the specific financial concepts required for the analysis. It provides a clear and consistent framework for ensuring the correct components are used for each analytical task.
+
+## **Section 5: A Scale-Dependent Framework for Volatility and Risk**
+
+This section operationalizes the theoretical properties of MODWT to deliver robust, multi-scale measures of volatility and a forward-looking framework for estimating price risk ranges. This approach moves beyond static, historical volatility calculations to a dynamic, model-based system that adapts to the changing structure of the market.
+
+### **5.1 Measuring Volatility Across Investment Horizons**
+
+As established in Section 1.2, the MODWT provides an exact, additive decomposition of the variance of a time series. This property is directly leveraged to create a scale-dependent measure of volatility.
+
+**Methodology:**
+
+1. Perform the MODWT on the log-return series of the financial instrument to a chosen level J. This yields J detail coefficient series (D1​,D2​,...,DJ​) and one smooth coefficient series (SJ​).  
+2. For each detail coefficient series Dj​, calculate its sample variance, Var(Dj​).  
+3. This value, Var(Dj​), is the unbiased estimate of the portion of the total price variance attributable to oscillations within the time scale corresponding to level j.15 For daily data,  
+   Var(D1​) represents the volatility from 2-4 day cycles, Var(D2​) from 4-8 day cycles, and so on.  
+4. The sum of these variances across all scales equals the total variance of the log-return series: Var(rt​)=∑j=1J​Var(Dj​)+Var(SJ​).
+
+Interpretation and Application:  
+Plotting these scale-based variances as a bar chart creates a "volatility spectrum" for the asset.15 This visualization provides immediate insight into the sources of risk. A stock with high variance at short scales (  
+D1​,D2​) is dominated by high-frequency noise, which might be a concern for a high-turnover strategy. Conversely, a stock with high variance concentrated at longer scales (D5​,D6​) is highly sensitive to the business cycle, indicating significant macroeconomic risk. This analysis allows for the construction of scale-aware portfolios, hedging strategies tailored to specific time horizons, and a more granular understanding of an asset's risk profile.
+
+### **5.2 Forecasting N-Day Risk Ranges: The "Sum-of-Parts" Approach**
+
+The objective here is to forecast a probabilistic range for the cumulative asset return over the next N days, which is a more sophisticated task than simple point forecasting. The "sum-of-parts" or "decompose-forecast-aggregate" methodology is perfectly suited for this, as it allows for the separate modeling of components with different statistical properties, leading to a more robust estimate of total forecast uncertainty.34 This approach is conceptually similar to calculating a multi-day Value at Risk (VaR).34
+
+**Step-by-Step Methodology:**
+
+1. **Decompose:** Apply the MODWT to the historical log-return series, rt​, to obtain the set of detail (Dj​) and smooth (SJ​) component time series.  
+2. **Forecast Each Component:** For each individual component series, fit an appropriate time series model to produce an N-step-ahead forecast. The choice of model should match the characteristics of the component:  
+   * **Detail Components (Dj​):** These components typically represent higher-frequency, stationary, and mean-reverting processes. A simple autoregressive model, AR(p), is often sufficient to capture their short-term dynamics. The model will produce N-day-ahead point forecasts, D^j,T+1​,...,D^j,T+N​, and the corresponding forecast error variances.14  
+   * **Smooth Component (SJ​):** This component captures the underlying low-frequency trend and is typically non-stationary. An Autoregressive Integrated Moving Average (ARIMA) model or a simple random walk with drift is a suitable choice. This model will produce N-day-ahead point forecasts, S^J,T+1​,...,S^J,T+N​, and their associated forecast error variances.  
+3. **Aggregate Forecasts and Variances:**  
+   * Point Forecast: The forecast for the total log-return at each future time step k (from 1 to N) is the sum of the individual component forecasts:
+
+     r^T+k​=S^J,T+k​+j=1∑J​D^j,T+k​
+
+     The cumulative N-day log-return forecast is then R^T,N​=∑k=1N​r^T+k​.  
+   * Forecast Variance: Because the MODWT using an orthogonal wavelet produces an approximately orthogonal decomposition, the variance of the total forecast error is the sum of the variances of the individual component forecast errors. The variance of the cumulative N-day return forecast is:  
+   $$ \text{Var}(\hat{R}{T, N}) = \sum{k=1}^{N} \left( \text{Var}(\hat{S}{J, T+k}) + \sum{j=1}^{J} \text{Var}(\hat{D}{j, T+k}) \right) $$
+     Let the total cumulative variance be $\\sigma^2{T, N}$.  
+4. **Construct the N-Day Risk Range:**  
+   * With the aggregated N-day cumulative forecast mean (μT,N​=R^T,N​) and standard deviation (σT,N​), the risk range can be constructed. Assuming the forecast errors are approximately normally distributed, a 95% confidence interval for the cumulative N-day log-return is:  
+     $$\\left$$  
+   * This interval provides a probabilistic forecast for the range of likely outcomes over the next N days. The lower bound of this range is analogous to a VaR estimate.
+
+The true power of this "sum-of-parts" method for risk management lies in its ability to construct a more robust probabilistic forecast. By modeling the uncertainty of each component separately—the high but predictable variance of the noise-like detail components and the growing uncertainty of the trending smooth component—the aggregated forecast variance provides a more realistic and dynamically adaptive estimate of risk than a simple extrapolation based on historical volatility.
+
+## **Section 6: Advanced Event Detection: Identifying Trend Reversals with Acceleration**
+
+The detection of major market turning points is one of the most challenging and valuable tasks in financial analysis. A simple indicator is rarely sufficient. A robust signal requires a confluence of evidence, capturing both the exhaustion of an existing trend and the emergence of new market dynamics. This section synthesizes the concepts of multi-scale decomposition and momentum analysis to construct a quantitative, two-factor signal for detecting trend reversals, directly addressing the user's request to use acceleration for this purpose.
+
+### **6.1 The Signature of a Turning Point: Acceleration of the Trend**
+
+A major trend reversal is, by definition, an inflection point in the smoothed, underlying trajectory of the asset's price. At a market top, an uptrend does not simply stop; it decelerates, flattens, and then begins to accelerate downwards. The key signal is therefore the **acceleration of the trend component** of the price series.
+
+**Methodology:**
+
+1. **Isolate the Trend:** Apply the MODWT to the **log-price** series (not log-returns) to a sufficiently high level (e.g., J=6 or J=7 for daily data) to capture the long-term trend. The resulting smooth component, SJ​, represents this underlying trend, stripped of higher-frequency noise and cycles. This component can be isolated using a Multi-Resolution Analysis (MRA) reconstruction.28  
+2. **Calculate Trend Velocity:** The velocity of the trend is its rate of change, calculated as the first derivative of the smooth component, vS​(t)=dtd​SJ​(t). This can be computed using a simple first difference, as SJ​ is already very smooth.  
+3. **Calculate Trend Acceleration:** The acceleration of the trend is the second derivative of the smooth component, aS​(t)=dt2d2​SJ​(t). This is calculated as the first difference of the trend velocity series, aS​(t)=vS​(t)−vS​(t−1).  
+4. **Generate Primary Signal:** A potential trend reversal is signaled by a **zero-crossing in the trend acceleration**.  
+   * A **peak** (reversal from up-trend to down-trend) is indicated when the trend acceleration crosses from positive to negative. This signifies that the upward momentum has stopped increasing and is now decreasing.  
+   * A **trough** (reversal from down-trend to up-trend) is indicated when the trend acceleration crosses from negative to positive. This signifies that the downward momentum has abated and is beginning to turn positive.
+
+### **6.2 Confirmation with Outlier Analysis in Detail Components**
+
+The trend acceleration signal, while powerful, can generate premature or false signals, especially during periods of consolidation. A robust system requires a confirmation factor that captures the shift in market character often associated with a true reversal. Major turning points are not quiet events; they are typically accompanied by a burst of uncertainty, volatility, and unusual activity as the market consensus breaks down.41 This activity is best detected not in the slow-moving trend, but in the mid-frequency cyclical components.
+
+**Methodology:**
+
+1. Simultaneously analyze the detail coefficients (Dj​) from the MODWT decomposition of the **log-return** series.  
+2. Focus on a mid-frequency component, such as D3​ (8-16 day cycles) or D4​ (16-32 day cycles). These scales often reflect the "market mood" and cyclical flows that are distinct from both high-frequency noise and the primary trend.  
+3. At or near the time of a zero-crossing in the trend acceleration, check for a **statistical outlier** in the chosen detail component. An outlier can be defined as a coefficient whose value exceeds a certain threshold, such as ±3 standard deviations of its own historical series.41
+
+This two-factor approach quantifies a common form of trader intuition: first, observe that the primary trend is losing steam (decelerating), and then look for a "catalyst" or a "panic" event (the outlier) to confirm that a genuine reversal is underway.
+
+### **6.3 Generating a Quantitative Reversal Signal**
+
+The combination of the primary signal (trend acceleration) and the confirmation signal (cyclical outlier) forms a complete, quantitative algorithm for detecting trend reversals.
+
+**Algorithm:**
+
+* **Input:** A time series of daily closing prices.  
+* **Processing:**  
+  1. Perform two separate MODWT decompositions:  
+     * On the **log-price** series to obtain the smooth trend component, SJ​.  
+     * On the **log-return** series to obtain the detail components, Dj​.  
+  2. From SJ​, calculate the trend acceleration series, aS​(t).  
+  3. From a chosen mid-frequency detail component (e.g., D3​), calculate its rolling standard deviation and identify outlier points where ∣D3​(t)∣\>3⋅σD3​.  
+* **Signal Generation:**  
+  * A **Sell Signal (-1)** is generated at time t if:  
+    * aS​(t)\<0 AND aS​(t−1)\>0 (Trend acceleration crosses from positive to negative).  
+    * AND an outlier is detected in D3​ within a small window around time t.  
+  * A **Buy Signal (+1)** is generated at time t if:  
+    * aS​(t)\>0 AND aS​(t−1)\<0 (Trend acceleration crosses from negative to positive).  
+    * AND an outlier is detected in D3​ within a small window around time t.  
+  * A **Neutral Signal (0)** is generated otherwise.  
+* **Output:** A ternary time series of \[+1, \-1, 0\] signals. This quantitative output can be directly integrated into a backtesting framework or an automated trading system, providing a robust, multi-scale, and data-driven approach to capturing major market turning points.
+
+## **Conclusion**
+
+The Maximal Overlap Discrete Wavelet Transform provides a sophisticated and powerful framework for analyzing financial time series, offering a significant advancement over traditional time-domain or frequency-domain methods. By decomposing data into multiple time scales, MODWT allows for a nuanced and granular investigation of market dynamics that aligns with the reality of heterogeneous market participants and overlapping economic cycles.
+
+This report has laid out a comprehensive and actionable guide for designing a suite of advanced financial analysis features based on MODWT. The key recommendations and methodologies are:
+
+1. **A "Best Practices" Triad:** For rigorous and reproducible financial analysis, the recommended approach is the combination of the **MODWT** for its shift-invariance, a **near-symmetric mother wavelet** (such as a Symlet) to minimize phase distortion, and **reflection boundary handling** to mitigate edge effects.  
+2. **Robust Python Implementation:** The PyWavelets library is the recommended tool, but its swt function must be used with care. Correct implementation requires **manual pre-padding** of the data and the use of the norm=True parameter to ensure the critical property of variance partitioning is preserved.  
+3. **Tailored Preprocessing:** Price and volume series must be treated differently. Price-based analyses of volatility and momentum should be performed on **log-returns**, while trend analysis requires **log-prices**. Volume analysis necessitates a **log-transform and detrending** to isolate the cyclical activity of interest.  
+4. **Advanced Feature Engineering:** The wavelet coefficients themselves can be interpreted as **multi-scale, smoothed derivatives**, providing robust measures of price velocity and acceleration that are superior to noisy finite-difference methods.  
+5. **Dynamic Risk Management:** The "sum-of-parts" methodology, which involves decomposing a series, forecasting each component individually, and then aggregating the results, provides a powerful framework for constructing **forward-looking N-day risk ranges** that are more adaptive and realistic than those based on static historical volatility.  
+6. **Multi-Factor Signal Generation:** A high-confidence signal for **detecting trend reversals** can be constructed by identifying a confluence of events across scales: a **zero-crossing in the acceleration of the long-term trend component** (derived from log-prices), confirmed by a **concurrent statistical outlier in a mid-frequency cyclical component** (derived from log-returns).
+
+By adopting these methodologies, quantitative analysts and financial data scientists can move beyond single-scale indicators and develop a deeper, multi-resolution understanding of market behavior. This framework enables the creation of more sophisticated trading strategies, more accurate risk management systems, and a more robust foundation for quantitative financial modeling.
+
+#### **Works cited**
+
+1. Maximum overlap discrete wavelet methods in modeling banking data \- ResearchGate, accessed September 20, 2025, [https://www.researchgate.net/publication/265819123\_Maximum\_overlap\_discrete\_wavelet\_methods\_in\_modeling\_banking\_data](https://www.researchgate.net/publication/265819123_Maximum_overlap_discrete_wavelet_methods_in_modeling_banking_data)  
+2. Wavelet Transform Application for/in Non-Stationary Time-Series Analysis: A Review \- MDPI, accessed September 20, 2025, [https://www.mdpi.com/2076-3417/9/7/1345](https://www.mdpi.com/2076-3417/9/7/1345)  
+3. MODWT Based Time Scale Decomposition Analysis of BSE and NSE Indexes Financial Time Series, accessed September 20, 2025, [https://www.m-hikari.com/ijma/ijma-2011/ijma-25-28-2011/kumaranujIJMA25-28-2011.pdf](https://www.m-hikari.com/ijma/ijma-2011/ijma-25-28-2011/kumaranujIJMA25-28-2011.pdf)  
+4. Discrete Wavelet Transform-Based Prediction of Stock Index \- arXiv, accessed September 20, 2025, [https://arxiv.org/pdf/1605.07278](https://arxiv.org/pdf/1605.07278)  
+5. Wavelet Analysis of Stock Returns and Total Index with Moving Average of Stock Returns and Total Index \- Iranian Journal of Accounting, Auditing and Finance, accessed September 20, 2025, [https://ijaaf.um.ac.ir/article\_45135\_2905b18e130d139a237795a00d78ad70.pdf](https://ijaaf.um.ac.ir/article_45135_2905b18e130d139a237795a00d78ad70.pdf)  
+6. Beyond the Time Domain: Recent Advances on Frequency Transforms in Time Series Analysis \- arXiv, accessed September 20, 2025, [https://arxiv.org/html/2504.07099v1](https://arxiv.org/html/2504.07099v1)  
+7. An Introduction to Wavelets for Economists \- Bank of Canada, accessed September 20, 2025, [https://www.bankofcanada.ca/wp-content/uploads/2010/02/wp02-3.pdf](https://www.bankofcanada.ca/wp-content/uploads/2010/02/wp02-3.pdf)  
+8. A Tutorial of the Wavelet Transform \- Duke People, accessed September 20, 2025, [https://people.duke.edu/\~hpgavin/SystemID/References/Liu-WaveletTransform-2010.pdf](https://people.duke.edu/~hpgavin/SystemID/References/Liu-WaveletTransform-2010.pdf)  
+9. Choose a Wavelet \- MATLAB & Simulink \- MathWorks, accessed September 20, 2025, [https://www.mathworks.com/help/wavelet/gs/choose-a-wavelet.html](https://www.mathworks.com/help/wavelet/gs/choose-a-wavelet.html)  
+10. (Inverse) Maximal Overlap Discrete Wavelet Transform — modwt \- Neuroconductor, accessed September 20, 2025, [https://neuroconductor.org/help/waveslim/reference/modwt.html](https://neuroconductor.org/help/waveslim/reference/modwt.html)  
+11. Stationary Wavelet Transform — PyWavelets Documentation, accessed September 20, 2025, [https://pywavelets.readthedocs.io/en/latest/ref/swt-stationary-wavelet-transform.html](https://pywavelets.readthedocs.io/en/latest/ref/swt-stationary-wavelet-transform.html)  
+12. Maximal Overlap Discrete Wavelet Transform • abbreviation is MODWT (pronounced 'mod WT') \- faculty.​washington.​edu, accessed September 20, 2025, [https://faculty.washington.edu/dbp/s530/PDFs/05-MODWT-2018.pdf](https://faculty.washington.edu/dbp/s530/PDFs/05-MODWT-2018.pdf)  
+13. A Wavelet-based Transformer Framework for Univariate Time Series Forecasting \- arXiv, accessed September 20, 2025, [https://arxiv.org/pdf/2209.03945](https://arxiv.org/pdf/2209.03945)  
+14. Analysis of Time Series Data Using Maximal Overlap Discrete Wavelet Transform Autoregressive Moving Average \- EUDL, accessed September 20, 2025, [https://eudl.eu/pdf/10.4108/eai.2-8-2019.2290519](https://eudl.eu/pdf/10.4108/eai.2-8-2019.2290519)  
+15. Wavelet Analysis of Financial Data \- MATLAB & Simulink Example, accessed September 20, 2025, [https://www.mathworks.com/help/wavelet/ug/wavelet-analysis-of-financial-data.html](https://www.mathworks.com/help/wavelet/ug/wavelet-analysis-of-financial-data.html)  
+16. Study on a mother wavelet optimization framework based on change-point detection of hydrological time series \- HESS, accessed September 20, 2025, [https://hess.copernicus.org/articles/27/2325/2023/hess-27-2325-2023.pdf](https://hess.copernicus.org/articles/27/2325/2023/hess-27-2325-2023.pdf)  
+17. A general approach to derivative calculation using wavelet transform \- ResearchGate, accessed September 20, 2025, [https://www.researchgate.net/publication/238171534\_A\_general\_approach\_to\_derivative\_calculation\_using\_wavelet\_transform](https://www.researchgate.net/publication/238171534_A_general_approach_to_derivative_calculation_using_wavelet_transform)  
+18. Additive Decomposition and Boundary Conditions in Wavelet-Based Forecasting Approaches \- Acta Oeconomica Pragensia, accessed September 20, 2025, [https://aop.vse.cz/pdfs/aop/2014/02/04.pdf](https://aop.vse.cz/pdfs/aop/2014/02/04.pdf)  
+19. Signal extension modes — PyWavelets Documentation, accessed September 20, 2025, [https://pywavelets.readthedocs.io/en/latest/ref/signal-extension-modes.html](https://pywavelets.readthedocs.io/en/latest/ref/signal-extension-modes.html)  
+20. modwt \- Maximal overlap discrete wavelet transform \- MATLAB \- MathWorks, accessed September 20, 2025, [https://www.mathworks.com/help/wavelet/ref/modwt.html](https://www.mathworks.com/help/wavelet/ref/modwt.html)  
+21. PyWavelets \- Wavelet Transforms in Python — PyWavelets Documentation, accessed September 20, 2025, [https://pywavelets.readthedocs.io/](https://pywavelets.readthedocs.io/)  
+22. PyWavelets \- PyPI, accessed September 20, 2025, [https://pypi.org/project/PyWavelets/](https://pypi.org/project/PyWavelets/)  
+23. Maximum overlap discrete wavelet transform (MODWT) \- Google Groups, accessed September 20, 2025, [https://groups.google.com/g/pywavelets/c/QVYR6U\_ltb4](https://groups.google.com/g/pywavelets/c/QVYR6U_ltb4)  
+24. MODWT Transform · Issue \#51 · PyWavelets/pywt \- GitHub, accessed September 20, 2025, [https://github.com/PyWavelets/pywt/issues/51](https://github.com/PyWavelets/pywt/issues/51)  
+25. pistonly/modwtpy: modwt in python \- GitHub, accessed September 20, 2025, [https://github.com/pistonly/modwtpy](https://github.com/pistonly/modwtpy)  
+26. Wavelet transform \- Python for climatology, oceanograpy and atmospheric science, accessed September 20, 2025, [https://scrapbox.io/pycoaj/Wavelet\_transform](https://scrapbox.io/pycoaj/Wavelet_transform)  
+27. Cryptocurrency price drivers: Wavelet coherence analysis revisited | PLOS One, accessed September 20, 2025, [https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0195200](https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0195200)  
+28. Wavelet-Based Trend Detection and Estimation \- University of Washington, accessed September 20, 2025, [https://staff.washington.edu/dbp/PDFFILES/trend-encyclo.pdf](https://staff.washington.edu/dbp/PDFFILES/trend-encyclo.pdf)  
+29. Maximal Overlap Discrete Wavelet Transform, Graph Theory And Backpropagation Neural Network In Stock Market Forecasting \- ResearchGate, accessed September 20, 2025, [https://www.researchgate.net/publication/326862582\_Maximal\_Overlap\_Discrete\_Wavelet\_Transform\_Graph\_Theory\_And\_Backpropagation\_Neural\_Network\_In\_Stock\_Market\_Forecasting](https://www.researchgate.net/publication/326862582_Maximal_Overlap_Discrete_Wavelet_Transform_Graph_Theory_And_Backpropagation_Neural_Network_In_Stock_Market_Forecasting)  
+30. The dynamic relationship between stock returns and trading volume revisited: A MODWT-VAR approach \- IDEAS/RePEc, accessed September 20, 2025, [https://ideas.repec.org/a/eee/finlet/v27y2018icp91-98.html](https://ideas.repec.org/a/eee/finlet/v27y2018icp91-98.html)  
+31. The dynamical relation between price changes and trading volume: A multidimensional clustering analysis \- PMC, accessed September 20, 2025, [https://pmc.ncbi.nlm.nih.gov/articles/PMC9838530/](https://pmc.ncbi.nlm.nih.gov/articles/PMC9838530/)  
+32. A New (Better?) Measure of Risk and Uncertainty: The Volatility of Acceleration \- CSSA, accessed September 20, 2025, [https://cssanalytics.wordpress.com/2014/11/28/a-new-better-measure-of-risk-and-uncertainty-the-volatility-of-acceleration/](https://cssanalytics.wordpress.com/2014/11/28/a-new-better-measure-of-risk-and-uncertainty-the-volatility-of-acceleration/)  
+33. Wavelet Analysis of Stock Returns and Aggregate Economic Activity | Request PDF, accessed September 20, 2025, [https://www.researchgate.net/publication/222258806\_Wavelet\_Analysis\_of\_Stock\_Returns\_and\_Aggregate\_Economic\_Activity](https://www.researchgate.net/publication/222258806_Wavelet_Analysis_of_Stock_Returns_and_Aggregate_Economic_Activity)  
+34. Wavelet-based Value At Risk Estimation \- TU Delft, accessed September 20, 2025, [https://filelist.tudelft.nl/TBM/Over%20faculteit/Afdelingen/Engineering%20Systems%20and%20Services/People/Professors%20emeriti/Jan%20van%20den%20Berg/MasterPhdThesis/yuri.pdf](https://filelist.tudelft.nl/TBM/Over%20faculteit/Afdelingen/Engineering%20Systems%20and%20Services/People/Professors%20emeriti/Jan%20van%20den%20Berg/MasterPhdThesis/yuri.pdf)  
+35. Improving asset return forecasts with wavelets | Macrosynergy, accessed September 20, 2025, [https://macrosynergy.com/research/improving-return-forecasts-with-wavelets/](https://macrosynergy.com/research/improving-return-forecasts-with-wavelets/)  
+36. Using Wavelet Transforms in Time Series Forecasting | by Amit Yadav \- Medium, accessed September 20, 2025, [https://medium.com/@amit25173/using-wavelet-transforms-in-time-series-forecasting-aeca30204ea2](https://medium.com/@amit25173/using-wavelet-transforms-in-time-series-forecasting-aeca30204ea2)  
+37. Wavelet-Based Equity VaR Estimation \- SOA, accessed September 20, 2025, [https://www.soa.org/4a17d2/globalassets/assets/files/resources/essays-monographs/2019-erm-symposium/mono-2019-erm-shang.pdf](https://www.soa.org/4a17d2/globalassets/assets/files/resources/essays-monographs/2019-erm-symposium/mono-2019-erm-shang.pdf)  
+38. Estimating Market Risk under a Wavelet-Based Approach: Mexican ..., accessed September 20, 2025, [https://www.researchgate.net/publication/232626860\_Estimating\_Market\_Risk\_under\_a\_Wavelet-Based\_Approach\_Mexican\_Case](https://www.researchgate.net/publication/232626860_Estimating_Market_Risk_under_a_Wavelet-Based_Approach_Mexican_Case)  
+39. Forecasting volatility by using wavelet transform, ARIMA and GARCH models, accessed September 20, 2025, [https://ideas.repec.org/a/spr/eurase/v13y2023i3d10.1007\_s40822-023-00243-x.html](https://ideas.repec.org/a/spr/eurase/v13y2023i3d10.1007_s40822-023-00243-x.html)  
+40. Financial time series forecasting using optimized multistage wavelet regression approach \- PMC, accessed September 20, 2025, [https://pmc.ncbi.nlm.nih.gov/articles/PMC9030684/](https://pmc.ncbi.nlm.nih.gov/articles/PMC9030684/)  
+41. Identifying the major reversals of the BIST-30 index by extreme ..., accessed September 20, 2025, [https://www.emerald.com/insight/content/doi/10.1108/JCMS-10-2017-002/full/html](https://www.emerald.com/insight/content/doi/10.1108/JCMS-10-2017-002/full/html)  
+42. Detecting stock market turning points using wavelet leaders method \- ResearchGate, accessed September 20, 2025, [https://www.researchgate.net/publication/347385514\_Detecting\_stock\_market\_turning\_points\_using\_wavelet\_leaders\_method](https://www.researchgate.net/publication/347385514_Detecting_stock_market_turning_points_using_wavelet_leaders_method)

--- a/docs/stock-analysis-plan.md
+++ b/docs/stock-analysis-plan.md
@@ -114,6 +114,14 @@ Module proposal: `src/portfolio_advisor/graphs/stocks.py` (separate from `graph.
 - `ComputeSmaNode`: computes 20/50/100/200 SMAs; writes `analysis/sma_20_50_100_200.json`
 - `CommitMetadataNode`: updates `meta.json` with `artifacts.*.last_updated` and `last_complete_trading_day`
 
+### Report images
+
+- Per-ticker `report/` directory contains rendered charts for Markdown embedding.
+- Currently generated:
+  - `report/candle_ohlcv_1y.png`: 1-year candlestick with volume (PNG, 1200×600, dpi=150).
+- Example embed in Markdown:
+  `![OHLCV 1Y](output/stocks/tickers/<slug>/report/candle_ohlcv_1y.png)`
+
 Entrypoints:
 - `update_ticker(ticker, requested_artifacts=all)`: ensures primary and requested analyses are fresh
 - `update_all_for_portfolio(tickers, requested_artifacts)`: batch orchestration from the main agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
   "pydantic-settings>=2.5",
   "python-dotenv>=1.0.1",
   "polygon-api-client>=1.13.0",
+  "pandas>=2.2",
+  "matplotlib>=3.9",
+  "mplfinance>=0.12.10b0",
 ]
 
 [project.optional-dependencies]

--- a/src/portfolio_advisor/stocks/db.py
+++ b/src/portfolio_advisor/stocks/db.py
@@ -32,6 +32,12 @@ class StockPaths:
     def analysis_sma_json(self, ticker: str) -> Path:
         return self.ticker_dir(ticker) / "analysis" / "sma_20_50_100_200.json"
 
+    def report_dir(self, ticker: str) -> Path:
+        return self.ticker_dir(ticker) / "report"
+
+    def report_candle_1y_png(self, ticker: str) -> Path:
+        return self.report_dir(ticker) / "candle_ohlcv_1y.png"
+
     def lock_dir(self, ticker: str) -> Path:
         return self.ticker_dir(ticker) / ".lock"
 
@@ -40,6 +46,7 @@ def ensure_ticker_scaffold(paths: StockPaths, ticker: str) -> None:
     base = paths.ticker_dir(ticker)
     (base / "primary").mkdir(parents=True, exist_ok=True)
     (base / "analysis").mkdir(parents=True, exist_ok=True)
+    (base / "report").mkdir(parents=True, exist_ok=True)
 
 
 def _read_json(path: Path) -> dict[str, Any] | list[dict[str, Any]]:

--- a/src/portfolio_advisor/stocks/plotting.py
+++ b/src/portfolio_advisor/stocks/plotting.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+# Use a non-interactive backend suitable for headless/threaded execution
+try:  # pragma: no cover - backend selection is environment dependent
+    import matplotlib  # type: ignore
+
+    matplotlib.use("Agg", force=True)
+except Exception:  # pragma: no cover - defensive
+    pass
+
+_plot_lock = threading.Lock()
+
+
+def _ohlc_to_dataframe(ohlc: dict[str, Any]):
+    """Convert primary OHLC dict to a pandas DataFrame indexed by date.
+
+    Expects keys: data: list[{date, open, high, low, close, volume}], coverage.end_date.
+    """
+    try:
+        import pandas as pd  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency missing is a runtime error
+        raise RuntimeError("pandas is required for plotting") from exc
+
+    rows = ohlc.get("data", []) or []
+    if not rows:
+        return None
+    df = pd.DataFrame(rows)
+    # Normalize columns and index
+    expected = ["date", "open", "high", "low", "close", "volume"]
+    for col in expected:
+        if col not in df.columns:
+            df[col] = None
+    df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    df = df.set_index("date").sort_index()
+    # Ensure numeric types
+    for c in ("open", "high", "low", "close"):
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+    df["volume"] = pd.to_numeric(df["volume"], errors="coerce").fillna(0).astype(int)
+    return df
+
+
+def render_candlestick_ohlcv_1y(output_dir: Path, ohlc: dict[str, Any]) -> Path | None:
+    """Render a 1-year candlestick chart with volume to output_dir/report.
+
+    Returns the written path, or None if data insufficient.
+    """
+    df = _ohlc_to_dataframe(ohlc)
+    if df is None or len(df) < 180:  # require ~6 months minimum
+        _logger.info("plotting.skip: insufficient data rows=%s", 0 if df is None else len(df))
+        return None
+
+    # Slice the last 252 trading days when available
+    tail = df.tail(252)
+    report_dir = output_dir / "report"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    out_path = report_dir / "candle_ohlcv_1y.png"
+
+    try:
+        import mplfinance as mpf  # type: ignore
+    except Exception as exc:  # pragma: no cover - dependency missing
+        raise RuntimeError("mplfinance is required for plotting") from exc
+
+    style = "yahoo"
+    savefig = dict(fname=str(out_path), dpi=150, bbox_inches="tight")
+    # Guard plotting with a lock to avoid global state races in Matplotlib
+    with _plot_lock:
+        mpf.plot(
+            tail,
+            type="candle",
+            volume=True,
+            style=style,
+            figsize=(12, 6),
+            tight_layout=True,
+            savefig=savefig,
+        )
+    return out_path

--- a/tests/test_stocks_plotting.py
+++ b/tests/test_stocks_plotting.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+from portfolio_advisor.stocks.plotting import render_candlestick_ohlcv_1y
+
+
+def _make_ohlc(days: int = 260) -> dict:
+    base = dt.date(2024, 1, 1)
+    rows = []
+    price = 100.0
+    for i in range(days):
+        d = base + dt.timedelta(days=i)
+        if d.weekday() >= 5:
+            continue
+        open_p = price
+        high_p = open_p * 1.01
+        low_p = open_p * 0.99
+        close_p = open_p * (1.0 + (0.002 if (i % 10) == 0 else -0.001))
+        price = close_p
+        rows.append(
+            {
+                "date": d.isoformat(),
+                "open": open_p,
+                "high": high_p,
+                "low": low_p,
+                "close": close_p,
+                "volume": 100000 + i,
+            }
+        )
+    coverage_end = rows[-1]["date"] if rows else None
+    return {
+        "instrument_id": "stocks:US:NASDAQ:AAPL",
+        "primary_ticker": "AAPL",
+        "data": rows,
+        "coverage": {"start_date": rows[0]["date"] if rows else None, "end_date": coverage_end},
+    }
+
+
+def test_render_candlestick_ohlcv_1y(tmp_path: Path):
+    ohlc = _make_ohlc(300)
+    out = render_candlestick_ohlcv_1y(tmp_path, ohlc)
+    assert out is not None
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_render_skips_on_short_data(tmp_path: Path):
+    ohlc = _make_ohlc(50)
+    out = render_candlestick_ohlcv_1y(tmp_path, ohlc)
+    assert out is None


### PR DESCRIPTION
Summary of changes:\n- Add mplfinance/matplotlib/pandas dependencies\n- Render 1Y candlestick (PNG) per ticker to report/candle_ohlcv_1y.png\n- Enforce Agg backend in headless/threaded runs\n- Integrate into stocks graph between SMA and metadata\n- Add tests and doc note\n\nImpact: images available for Markdown embedding at output/stocks/tickers/<slug>/report/candle_ohlcv_1y.png\n\nRisks: minimal; plotting guarded with Agg backend and lock